### PR TITLE
Fix broken links to blog posts in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ page](https://github.com/CertiKFoundation/deepsea/releases). Please see the [Dee
 The zip file includes pre-built binaries for Linux (Ubuntu) and MacOS. Since they use some system libraries, it is possible that they will not work on every version of Linux or MacOS. It is also easy to build the binaries from source yourself, following the instructions in the `src` directory.
 
 [The project page at the CertiK website](https://certik.io/research/deepsea/)
-has more information about the DeepSEA project, including the blog posts [An Introduction to DeepSEA](https://certik.io/blog/technology/an-introduction-to-deepsea) and [How DeepSEA Works](https://certik.io/blog/technology/how-deepsea-works-with-an-example-token-contact/).  
+has more information about the DeepSEA project, including the blog posts [An Introduction to DeepSEA](https://www.certik.com/resources/blog/an-introduction-to-deepsea) and [How DeepSEA Works](https://www.certik.com/resources/blog/how-deepsea-works-with-an-example-token-contact).  
 
 The DeepSEA compiler includes files taken and modified from CompCert, so it is developed pursuant to the CompCert licence. In particular, it may only be used for educational, research, personal or evaluation purposes, and not for commercial use.
 


### PR DESCRIPTION
@vilhelms, this pull request fixes the two broken links to blog posts about DeepSEA in the README.

The link to the project page at the CertiK website: https://certik.io/research/deepsea/ is also broken, but this pull request does not fix that.